### PR TITLE
Master

### DIFF
--- a/staging/dwtools/abase/layer5/Cloner.s
+++ b/staging/dwtools/abase/layer5/Cloner.s
@@ -243,7 +243,7 @@ function _cloneBufferUp( src, it )
     it.dst = it.src;
   }
 
-  return it;
+  // return it;
 }
 
 //


### PR DESCRIPTION
chainer must get undefined from _cloneBufferUp  to make proper arguments for onBuffer